### PR TITLE
fix: allow project cards to shrink below image width on home page

### DIFF
--- a/frontend/src/assets/stylesheets/main.scss
+++ b/frontend/src/assets/stylesheets/main.scss
@@ -800,6 +800,7 @@ main {
 			margin-bottom: 4em;
 			div {
 				flex-basis: calc(33.33% - 0.5em);
+				min-width: 0;
 				margin-bottom: 1.5em;
 				padding: 1.5em 0.7em 1em 0.7em;
 				background-color: lighten($lightgray, 5%);


### PR DESCRIPTION
Added min-width: 0 on line 803. This overrides flexbox's default min-width: auto, which was preventing the project cards from shrinking below the image's intrinsic 1200px width. Now all 3 cards will properly fit to calc(33.33% - 0.5em) in one row.