### PR TITLE
fix: enable word wrapping for project descriptions on the homepage

### DIFF
--- a/frontend/src/assets/stylesheets/main.scss
+++ b/frontend/src/assets/stylesheets/main.scss
@@ -804,6 +804,9 @@ main {
 				margin-bottom: 1.5em;
 				padding: 1.5em 0.7em 1em 0.7em;
 				background-color: lighten($lightgray, 5%);
+				p {
+					overflow-wrap: break-word;
+				}
 			}
 			a {
 				text-decoration: none;


### PR DESCRIPTION
picture was fixed, but I also need the text below to break. when eleventy builds the site, it bakes the 3 chosen projects into the static HTML. Every visitor sees the same 3 until the site is rebuilt. this time it was slavery in war, maybe next time it will not be, but I fixed it:
<img width="1636" height="723" alt="Screenshot 2026-06-01 at 15 10 46" src="https://github.com/user-attachments/assets/78ba951f-d4f5-42e4-a514-97738c06e080" />
