### PR TITLE
Update team registry — visiting staff additions and removal

### DIFF
--- a/frontend/src/_data/team.json
+++ b/frontend/src/_data/team.json
@@ -180,15 +180,6 @@
 		}
 	},
 	{
-		"slug": "katherine-bode",
-		"jobTitle": "Visiting Research Fellow",
-		"team": "Research fellows",
-		"feature": {
-			"image": "/assets/images/people/katherine-bode.jpg",
-			"description": "Photo of Katherine Bode"
-		}
-	},
-	{
 		"slug": "ginestra-ferraro",
 		"jobTitle": "Visiting Research Fellow",
 		"team": "Research fellows",
@@ -376,6 +367,15 @@
 		"feature": {
 			"image": "/assets/images/people/miguel-vieira.jpg",
 			"description": "Photo of Miguel Vieira"
+		}
+	},
+	{
+		"slug": "james-smithies",
+		"jobTitle": "Visiting Professor",
+		"team": "Research fellows",
+		"feature": {
+			"image": "/assets/images/people/james-smithies.jpg",
+			"description": "Photo of Dr. James Smithies"
 		}
 	},
 	{

--- a/frontend/src/_data/team.json
+++ b/frontend/src/_data/team.json
@@ -335,8 +335,8 @@
 	},
 	{
 		"slug": "brian-maher",
-		"jobTitle": "Former Senior Research Software Engineer & Research Software Systems Manager",
-		"team": "Former staff",
+		"jobTitle": "Visiting Research Fellow",
+		"team": "Research fellows",
 		"feature": {
 			"image": "/assets/images/people/brian-maher.jpg",
 			"description": "Photo of Brian Maher"
@@ -358,6 +358,33 @@
 		"feature": {
 			"image": "/assets/images/people/ryan-heuser.jpg",
 			"description": "Photo of Ryan Heuser"
+		}
+	},
+	{
+		"slug": "tiffany-ong",
+		"jobTitle": "Visiting Research Fellow",
+		"team": "Research fellows",
+		"feature": {
+			"image": "/assets/images/people/tiffany-ong.jpg",
+			"description": "Photo of Tiffany Ong"
+		}
+	},
+	{
+		"slug": "miguel-vieira",
+		"jobTitle": "Visiting Research Fellow",
+		"team": "Research fellows",
+		"feature": {
+			"image": "/assets/images/people/miguel-vieira.jpg",
+			"description": "Photo of Miguel Vieira"
+		}
+	},
+	{
+		"slug": "brian-maher",
+		"jobTitle": "Former Senior Research Software Engineer & Research Software Systems Manager",
+		"team": "Former staff",
+		"feature": {
+			"image": "/assets/images/people/brian-maher.jpg",
+			"description": "Photo of Brian Maher"
 		}
 	},
 	{


### PR DESCRIPTION

- Added duplicate team entries for three former staff members, matching the existing pattern of a Research fellows entry alongside their existing Former staff entry, consistent with the convention used for other visiting research fellows.
- Added a new Visiting Professor entry to Research fellows for a former staff member, retaining their existing Former staff entry.
- Removed one Research fellows entry for a visiting research fellow who is no longer affiliated.