### PR TITLE
fix(clickup-to-md): stop exposing internal assignee fields as project…

### DIFF
--- a/etl/src/clickup-to-md.js
+++ b/etl/src/clickup-to-md.js
@@ -306,28 +306,6 @@ class ClickUpToMarkdown {
 	getMembers(data) {
 		const members = [];
 
-		for (const role of ["Analyst", "Design", "Dev"]) {
-			const field = data.custom_fields.find((field) => field.name === role);
-			const roleName =
-				role === "Analyst"
-					? "Research Software Analyst"
-					: role === "Design"
-						? "Research Software Designer"
-						: "Research Software Engineer";
-
-			if (field && field.value) {
-				field.value
-					.filter((member) => member)
-					.forEach((member) => {
-						members.push({
-							name: member.username.trim(),
-							slug: this.slugify(member.username.trim()),
-							roleName,
-						});
-					});
-			}
-		}
-
 		const kdlStaffField = data.custom_fields.find((field) => field.name === "KDL staff");
 
 		if (kdlStaffField && kdlStaffField.value) {

--- a/frontend/src/projects/2000-01-01-pbw.md
+++ b/frontend/src/projects/2000-01-01-pbw.md
@@ -33,9 +33,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Elliott Hall
     slug: elliott-hall
     roleName: Research Software Engineer

--- a/frontend/src/projects/2004-04-01-charm.md
+++ b/frontend/src/projects/2004-04-01-charm.md
@@ -35,11 +35,11 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Miguel Vieira
     slug: miguel-vieira
+    roleName: Research Software Engineer
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
     roleName: Research Software Engineer
   - name: Paul Caton
     slug: paul-caton

--- a/frontend/src/projects/2004-10-01-langscape.md
+++ b/frontend/src/projects/2004-10-01-langscape.md
@@ -27,9 +27,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
   - name: Miguel Vieira
     slug: miguel-vieira
     roleName: Research Software Engineer

--- a/frontend/src/projects/2007-08-01-paradox-of-medieval-scotland-examining-the-roles-and-relationships-of-medieval-scottish-society.md
+++ b/frontend/src/projects/2007-08-01-paradox-of-medieval-scotland-examining-the-roles-and-relationships-of-medieval-scottish-society.md
@@ -29,9 +29,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst

--- a/frontend/src/projects/2008-03-01-henry-iii-fine-rolls.md
+++ b/frontend/src/projects/2008-03-01-henry-iii-fine-rolls.md
@@ -31,9 +31,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Mary Chester-Kadwell
-    slug: mary-chester-kadwell
-    roleName: Research Software Engineer
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst

--- a/frontend/src/projects/2009-01-01-inscriptions-of-roman-tripolitania.md
+++ b/frontend/src/projects/2009-01-01-inscriptions-of-roman-tripolitania.md
@@ -29,9 +29,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Mary Chester-Kadwell
-    slug: mary-chester-kadwell
-    roleName: Research Software Engineer
   - name: Arianna Ciula
     slug: arianna-ciula
     roleName: Research Software Analyst

--- a/frontend/src/projects/2010-01-01-aofm.md
+++ b/frontend/src/projects/2010-01-01-aofm.md
@@ -27,9 +27,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
   - name: Samantha Callaghan
     slug: samantha-callaghan
     roleName: Research Software Analyst

--- a/frontend/src/projects/2010-10-01-digipal.md
+++ b/frontend/src/projects/2010-10-01-digipal.md
@@ -29,12 +29,12 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst

--- a/frontend/src/projects/2011-04-01-medieval-francophone-literature-outside-france.md
+++ b/frontend/src/projects/2011-04-01-medieval-francophone-literature-outside-france.md
@@ -26,12 +26,12 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst
+  - name: Geoffroy Noel
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Ginestra Ferraro
     slug: ginestra-ferraro
     roleName: Research Software Designer

--- a/frontend/src/projects/2012-01-01-mkcheur.md
+++ b/frontend/src/projects/2012-01-01-mkcheur.md
@@ -27,9 +27,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Mary Chester-Kadwell
-    slug: mary-chester-kadwell
-    roleName: Research Software Engineer
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst

--- a/frontend/src/projects/2012-09-01-ibcc.md
+++ b/frontend/src/projects/2012-09-01-ibcc.md
@@ -25,9 +25,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst

--- a/frontend/src/projects/2013-01-01-hp.md
+++ b/frontend/src/projects/2013-01-01-hp.md
@@ -29,9 +29,6 @@ departments:
   - name: University of Edinburgh
     slug: university-of-edinburgh
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Miguel Vieira
     slug: miguel-vieira
     roleName: Research Software Engineer
@@ -44,6 +41,9 @@ members:
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Paul Readman
     slug: paul-readman
     roleName: Principal investigator

--- a/frontend/src/projects/2013-10-01-dprr.md
+++ b/frontend/src/projects/2013-10-01-dprr.md
@@ -31,9 +31,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
   - name: Luís Figueira
     slug: luis-figueira
     roleName: Research Software Engineer

--- a/frontend/src/projects/2013-10-01-moi.md
+++ b/frontend/src/projects/2013-10-01-moi.md
@@ -29,9 +29,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
   - name: Elliott Hall
     slug: elliott-hall
     roleName: Research Software Engineer

--- a/frontend/src/projects/2014-10-01-exon-domesday.md
+++ b/frontend/src/projects/2014-10-01-exon-domesday.md
@@ -31,12 +31,12 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Julia Crick
     slug: julia-crick
     roleName: Principal investigator

--- a/frontend/src/projects/2015-09-01-tvof.md
+++ b/frontend/src/projects/2015-09-01-tvof.md
@@ -36,12 +36,12 @@ departments:
   - name: Cambridge University
     slug: cambridge-university
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Miguel Vieira
     slug: miguel-vieira
     roleName: Research Software Engineer

--- a/frontend/src/projects/2016-07-01-owri.md
+++ b/frontend/src/projects/2016-07-01-owri.md
@@ -26,9 +26,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Mary Chester-Kadwell
-    slug: mary-chester-kadwell
-    roleName: Research Software Engineer
   - name: Ginestra Ferraro
     slug: ginestra-ferraro
     roleName: Research Software Designer

--- a/frontend/src/projects/2017-08-01-cotr.md
+++ b/frontend/src/projects/2017-08-01-cotr.md
@@ -28,15 +28,15 @@ departments:
   - name: University of Edinburgh
     slug: university-of-edinburgh
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Ginestra Ferraro
     slug: ginestra-ferraro
     roleName: Research Software Designer
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Alice Taylor
     slug: alice-taylor
     roleName: Principal investigator

--- a/frontend/src/projects/2017-08-01-nineteenth-century-serials-edition.md
+++ b/frontend/src/projects/2017-08-01-nineteenth-century-serials-edition.md
@@ -36,9 +36,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Tiffany Ong
     slug: tiffany-ong
     roleName: Research Software Designer

--- a/frontend/src/projects/2018-01-08-culture-case.md
+++ b/frontend/src/projects/2018-01-08-culture-case.md
@@ -24,12 +24,12 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Arianna Ciula
     slug: arianna-ciula
     roleName: Research Software Analyst
+  - name: Geoffroy Noel
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Tiffany Ong
     slug: tiffany-ong
     roleName: Research Software Designer

--- a/frontend/src/projects/2018-04-01-mao-era-in-objects.md
+++ b/frontend/src/projects/2018-04-01-mao-era-in-objects.md
@@ -28,9 +28,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Tiffany Ong
     slug: tiffany-ong
     roleName: Research Software Designer

--- a/frontend/src/projects/2018-09-01-field.md
+++ b/frontend/src/projects/2018-09-01-field.md
@@ -29,11 +29,11 @@ members:
   - name: Neil Jakeman
     slug: neil-jakeman
     roleName: Research Software Analyst
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Elliott Hall
     slug: elliott-hall
+    roleName: Research Software Engineer
+  - name: Geoffroy Noel
+    slug: geoffroy-noel
     roleName: Research Software Engineer
   - name: Miguel Vieira
     slug: miguel-vieira

--- a/frontend/src/projects/2018-10-01-gpp.md
+++ b/frontend/src/projects/2018-10-01-gpp.md
@@ -43,9 +43,6 @@ departments:
   - name: Royal Household
     slug: royal-household
 members:
-  - name: Paul Caton
-    slug: paul-caton
-    roleName: Research Software Analyst
   - name: Olga Loboda
     slug: olga-loboda
     roleName: Research Software Designer
@@ -63,6 +60,9 @@ members:
     roleName: Research Software Analyst
   - name: Samantha Callaghan
     slug: samantha-callaghan
+    roleName: Research Software Analyst
+  - name: Paul Caton
+    slug: paul-caton
     roleName: Research Software Analyst
   - name: Brian Maher
     slug: brian-maher

--- a/frontend/src/projects/2020-01-01-ircyr.md
+++ b/frontend/src/projects/2020-01-01-ircyr.md
@@ -26,9 +26,6 @@ departments:
   - name: King's College, London
     slug: kings-college-london
 members:
-  - name: Mary Chester-Kadwell
-    slug: mary-chester-kadwell
-    roleName: Research Software Engineer
   - name: Tim Watts
     slug: tim-watts
     roleName: Research Software Systems Administrator

--- a/frontend/src/projects/2021-09-01-at.md
+++ b/frontend/src/projects/2021-09-01-at.md
@@ -25,14 +25,14 @@ members:
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
   - name: Arianna Ciula
     slug: arianna-ciula
     roleName: Research Software Analyst
   - name: Mary Chester-Kadwell
     slug: mary-chester-kadwell
+    roleName: Research Software Engineer
+  - name: Geoffroy Noël
+    slug: geoffroy-noel
     roleName: Research Software Engineer
   - name: Ginestra Ferraro
     slug: ginestra-ferraro

--- a/frontend/src/projects/2023-06-30-king-s-past.md
+++ b/frontend/src/projects/2023-06-30-king-s-past.md
@@ -31,9 +31,6 @@ members:
   - name: Samantha Callaghan
     slug: samantha-callaghan
     roleName: Research Software Analyst
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
   - name: Miguel Vieira
     slug: miguel-vieira
     roleName: Research Software Engineer

--- a/frontend/src/projects/2024-01-01-step-up.md
+++ b/frontend/src/projects/2024-01-01-step-up.md
@@ -32,11 +32,11 @@ departments:
   - name: University College London
     slug: university-college-london
 members:
-  - name: Miguel Vieira
-    slug: miguel-vieira
-    roleName: Research Software Engineer
   - name: Mary Chester-Kadwell
     slug: mary-chester-kadwell
+    roleName: Research Software Engineer
+  - name: Miguel Vieira
+    slug: miguel-vieira
     roleName: Research Software Engineer
   - name: Zihao Lu
     slug: zihao-lu

--- a/frontend/src/projects/2024-02-01-ireal.md
+++ b/frontend/src/projects/2024-02-01-ireal.md
@@ -33,9 +33,6 @@ departments:
   - name: Digital Preservation Coalition
     slug: digital-preservation-coalition
 members:
-  - name: Samantha Callaghan
-    slug: samantha-callaghan
-    roleName: Research Software Analyst
   - name: Miguel Vieira
     slug: miguel-vieira
     roleName: Research Software Engineer

--- a/frontend/src/projects/2025-01-16-intelligent-systems-for-screen-archivesv-issa.md
+++ b/frontend/src/projects/2025-01-16-intelligent-systems-for-screen-archivesv-issa.md
@@ -48,6 +48,9 @@ members:
   - name: Geoffroy Noel
     slug: geoffroy-noel
     roleName: Research Software Engineer
+  - name: Stefan Meier
+    slug: stefan-meier
+    roleName: Research Software Engineer
   - name: Tiffany Ong
     slug: tiffany-ong
     roleName: Research Software Designer

--- a/frontend/src/projects/2025-01-16-intelligent-systems-for-screen-archivesv-issa.md
+++ b/frontend/src/projects/2025-01-16-intelligent-systems-for-screen-archivesv-issa.md
@@ -39,18 +39,15 @@ members:
   - name: Arianna Ciula
     slug: arianna-ciula
     roleName: Research Software Analyst
-  - name: Geoffroy Noël
-    slug: geoffroy-noel
-    roleName: Research Software Engineer
-  - name: Stefan Meier
-    slug: stefan-meier
-    roleName: Research Software Engineer
-  - name: Miguel Vieira
-    slug: miguel-vieira
-    roleName: Research Software Engineer
   - name: Paul Caton
     slug: paul-caton
     roleName: Research Software Analyst
+  - name: Miguel Vieira
+    slug: miguel-vieira
+    roleName: Research Software Engineer
+  - name: Geoffroy Noel
+    slug: geoffroy-noel
+    roleName: Research Software Engineer
   - name: Tiffany Ong
     slug: tiffany-ong
     roleName: Research Software Designer


### PR DESCRIPTION
… members

The Dev/Analyst/Design custom fields are ClickUp assignee/maintenance fields (e.g. the current task assignee), not the original development team. They were being flattened into project page members, so people appeared on projects they never worked on. Only the KDL staff field (the original team, with granular roles) is now exposed.